### PR TITLE
Add previous value upon removal at internal stem node

### DIFF
--- a/src/main/java/org/hyperledger/besu/ethereum/stateless/node/BranchNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/stateless/node/BranchNode.java
@@ -202,9 +202,10 @@ public abstract class BranchNode<V> extends Node<V> {
    *
    * @return previous hash of this node
    */
+  @SuppressWarnings("unchecked")
   @Override
-  public Optional<Bytes32> getPrevious() {
-    return previous.map(Bytes32.class::cast);
+  public Optional<V> getPrevious() {
+    return previous.map(o -> (V) o);
   }
 
   /**

--- a/src/main/java/org/hyperledger/besu/ethereum/stateless/node/NullNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/stateless/node/NullNode.java
@@ -152,6 +152,10 @@ public class NullNode<V> extends Node<V> {
     return nullNode;
   }
 
+  public static <T> NullNode<T> nullNode(Optional<T> previousValue) {
+    return new NullNode<>(previousValue);
+  }
+
   @SuppressWarnings("unchecked")
   public static <T> NullNode<T> newNullLeafNode() {
     if (nullLeafNode == null) {

--- a/src/main/java/org/hyperledger/besu/ethereum/stateless/visitor/PutVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/stateless/visitor/PutVisitor.java
@@ -98,7 +98,7 @@ public class PutVisitor<V> implements PathNodeVisitor<V> {
       final byte index = fullPath.get(newStem.size());
       visited = Bytes.concatenate(visited, Bytes.of(index));
       final Node<V> child = stemNode.child(index);
-      final Node<V> updatedChild = stemNode.child(index).accept(this, path.slice(1));
+      final Node<V> updatedChild = child.accept(this, path.slice(1));
       if (child instanceof NullNode<V>) {
         // This call may lead to the removal of the node from the batch if a null node
         // is inserted.

--- a/src/main/java/org/hyperledger/besu/ethereum/stateless/visitor/RemoveVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/stateless/visitor/RemoveVisitor.java
@@ -100,7 +100,7 @@ public class RemoveVisitor<V> implements PathNodeVisitor<V> {
     final Node<V> updatedChild = child.accept(this, path);
     stemNode.replaceChild(childIndex, updatedChild);
     if (allLeavesAreNull(stemNode)) {
-      final NullNode<V> nullNode = NullNode.nullNode();
+      final NullNode<V> nullNode = NullNode.nullNode(stemNode.getPrevious());
       nullNode.markDirty();
       batchProcessor.ifPresent(
           processor -> processor.addNodeToBatch(stemNode.getLocation(), nullNode));


### PR DESCRIPTION
## PR description
I noticed a bug while computing the commitment for an `InternalNode` where we were not taking into account the previous value while removing a node downstream from the stem.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->