### PR TITLE
Add git commit hash to jar file MANIFEST

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,7 @@ allprojects {
         'Specification-Version': project.version,
         'Implementation-Title': archiveBaseName,
         'Implementation-Version': project.version,
+        'Commit-Hash': getCommitHash(),
         'Automatic-Module-Name': 'org.hyperledger.besu.stateless'
         )
     }
@@ -277,6 +278,15 @@ task checkSpdxHeader(type: CheckSpdxHeader) {
     "(.*${sep}build${sep}.*)",
     "(.*${sep}src${sep}[^${sep}]+${sep}generated${sep}.*)"
   ].join("|")
+}
+
+def getCommitHash() {
+  def stdout = new ByteArrayOutputStream()
+  exec {
+    commandLine 'git', 'rev-parse', 'HEAD'
+    standardOutput = stdout
+  }
+  return stdout.toString().trim()
 }
 
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->

## PR description
We often add the commit hash on the consumer of this dependency but, since it's useful, we should rather add the hash on the dependency itself so whoever uses it knows what hash corresponds to what version.

![image](https://github.com/user-attachments/assets/b848ad6c-0719-4c95-ade0-1f2c5f0bfb23)


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->